### PR TITLE
build: set base to `/website/`

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -5,6 +5,7 @@ import vue from "@vitejs/plugin-vue";
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  base: '/website/',
   plugins: [vue()],
   resolve: {
     alias: {


### PR DESCRIPTION
 ## Changes

Our website is deployed at https://busfaktor.github.io/website/. Note
the trailing folder `/website/`. So, any assets (JS/CSS files) will lead
to a 404 because Github puts them under `/website`, too. So the
`index.html` must reference them correctly.

See: https://vitejs.dev/config/#base

 ## Other

I find the build process a little confusing that we have to switch to
`gh-pages`, remove all files and then copy updated build files to the
root directory.

Here you can set the output folder to e.g. `/docs/`.
https://github.com/busFaktor/website/settings/pages

I searched for a second for `Github pages action` and found:
https://github.com/JamesIves/github-pages-deploy-action
Looks promising but maybe you could also research a little more about
alternatives.